### PR TITLE
Router Links fixed

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -6,20 +6,20 @@
         <a href="./" class="brand-logo hide-on-med-and-down" style="font-size:20px;">Coding&nbsp;Club&nbsp;IIT&nbsp;Jammu</a>
       </div>
       <ul class="right hide-on-med-and-down">
-        <li><a href="/events">Activities</a></li>
-        <li><a href="/team">Team</a></li>
-        <li><a href="/member">Members</a></li>
+        <li><a routerLink="/events">Activities</a></li>
+        <li><a routerLink="/team">Team</a></li>
+        <li><a routerLink="/member">Members</a></li>
       </ul>
       <a href="#" data-target="nav-mobile" class="sidenav-trigger"><i class="material-icons">menu</i></a>
     </div>
   </nav>
 </div>
 <ul id="nav-mobile" class="sidenav blue lighten-5" style="padding-top: 20px;">
-  <li><a href="/events">Activities</a></li>
-  <li><a href="/team">Team</a></li>
-  <li><a href="/member">Members</a></li>
+  <li><a routerLink="/events">Activities</a></li>
+  <li><a routerLink="/team">Team</a></li>
+  <li><a routerLink="/member">Members</a></li>
 </ul>
-<router-outlet></router-outlet>   
+<router-outlet></router-outlet>
 <footer class="page-footer blue">
   <div>
     <div class="row">


### PR DESCRIPTION
Before:
Clicking on navigation links reloads the entire app which results in slow experience and high network usage.

Now:
Routes changes without reloading of whole app.